### PR TITLE
add a ftplugin for setting cms

### DIFF
--- a/ftplugin/systemd.vim
+++ b/ftplugin/systemd.vim
@@ -1,0 +1,8 @@
+" Generally, buffer-local things for systemd files.
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+
+" Makes for easier commenting -- particularly with tools like
+" tpope/vim-commentary that depend on this setting
+set cms=#\ %s


### PR DESCRIPTION
A good commentstring setting is important for tools that depend on it to
figure out how to comment/uncomment lines in a file.  One such tool is
tpope/vim-commentary.