### PR TITLE
Add more % template chars

### DIFF
--- a/syntax/systemd.vim
+++ b/syntax/systemd.vim
@@ -18,7 +18,7 @@ syn match sdErr contained /\s*\S\+/ nextgroup=sdErr
 
 " environment args and format strings
 syn match sdEnvArg    contained /\$\i\+\|\${\i\+}/
-syn match sdFormatStr contained /%[inpINPfcrRt]/ containedin=ALLBUT,sdComment,sdErr
+syn match sdFormatStr contained /%[bCEfhHiIjJLmnNpPsStTgGuUvV%]/ containedin=ALLBUT,sdComment,sdErr
 
 " common data types
 syn match sdUInt     contained nextgroup=sdErr /\d\+/


### PR DESCRIPTION
When writing a systemd unit that uses `%h`, I realized that the syntax definition was missing some `%` specifiers. I went through the man page for systemd.unit and added all `%` specifiers from the table there.